### PR TITLE
Enhanced json type support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tags
 .murano/
 .env
 .jiramulerc
+.vscode/
 
 luacov.*.out*
 modules/doc

--- a/modules/insight.lua
+++ b/modules/insight.lua
@@ -302,7 +302,7 @@ local function save_outlets(id, outlets)
     }
     for _,sd in pairs(outlet) do
       ow.ts = sd.ts
-      ow.metrics[lid .. '_' .. tostring(idx)] = sd.value
+      ow.metrics[lid .. '_' .. tostring(idx)] = type(sd.value) == 'table' and json.stringify(sd.value) or sd.value
       -- Just overwrite multiples. should all be same anyhow.
     end
     if next(ow.metrics) ~= nil then


### PR DESCRIPTION
Added table (json) serialization for saving outlet data; so that one can still output an "object" which can be interacted-with more meaningfully later in the pipeline, while also being able to access 'prior' data for that outlet within the relevant insight function.

Note:
- It is then the responsibility of the function author to deserialize the prior outlet value(s) for interaction
  - Should be documented
- I wonder whether save_inlets would benefit from the same additional handling
  - I have not tested but suppose json-type inlet data could be being serialized on the way in already